### PR TITLE
Prevent simple authcheck cookie bypass.

### DIFF
--- a/MasqrBackend/index.js
+++ b/MasqrBackend/index.js
@@ -24,7 +24,6 @@ app.use(async (req, res, next) => {
         const licenseCheck = (await (await fetch(LICENSE_SERVER_URL + pass + "&host=" + req.headers.host)).json())["status"]
         console.log(LICENSE_SERVER_URL + pass + "&host=" + req.headers.host +" returned " +licenseCheck)
         if (licenseCheck == "License valid") {
-            res.cookie("authcheck", "true") // authorize session
             next();
             return;
         } else {

--- a/MasqrBackend/index.js
+++ b/MasqrBackend/index.js
@@ -20,7 +20,7 @@ app.use(async (req, res, next) => {
         // Bypass for UV and other bares
     }
     if (req.cookies["authcheck"]) {
-        const pass = req.cookies.authToken;
+        const pass = req.cookies.authcheck;
         const licenseCheck = (await (await fetch(LICENSE_SERVER_URL + pass + "&host=" + req.headers.host)).json())["status"]
         console.log(LICENSE_SERVER_URL + pass + "&host=" + req.headers.host +" returned " +licenseCheck)
         if (licenseCheck == "License valid") {

--- a/MasqrBackend/index.js
+++ b/MasqrBackend/index.js
@@ -31,7 +31,7 @@ app.use(async (req, res, next) => {
             res.setHeader('WWW-Authenticate', 'Basic');
             err.status = 401;
             res.setHeader("Content-Type", "text/html"); 
-            res.send(401, failureFile)
+            return res.status(401).send(failureFile);
         }
     }
 
@@ -50,7 +50,7 @@ app.use(async (req, res, next) => {
         res.setHeader('WWW-Authenticate', 'Basic');
         err.status = 401;
         res.setHeader("Content-Type", "text/html"); 
-        res.send(401, failureFile)
+        res.status(401).send(failureFile)
         return;
     }
  


### PR DESCRIPTION
Makes a pretty simple change.
Prevents people from doing ```document.cookie = "authcheck=true";```

It saves the password as authcheck, verifies the cookie with the license server.